### PR TITLE
Exiting the container falls back to localhost

### DIFF
--- a/exercise-2/optional.md
+++ b/exercise-2/optional.md
@@ -26,8 +26,6 @@ root@helloworld-...:/app/src# hostname -i
 
 root@helloworld-...:/app/src# exit
 
-root@helloworld-...:/data# hostname -i
-10.104.1.5
 ```
 
 #### [Continue to Exercise 3 - Creating a Kubernetes Service](../exercise-3/README.md)


### PR DESCRIPTION
`kubectl exec -it` starts an interactive session with the container. Exiting the container (`
root@helloworld-...:/app/src# exit`) will throw the user out of the session to the computer kubectl was executed on. Running `hostname -i` afterwards therefore does not show the node's IP. It shows the IP of the computer kubectl was run on.

Removed the lines to not cause confusion.